### PR TITLE
Improved device handling

### DIFF
--- a/custom_components/electrolux_status/__init__.py
+++ b/custom_components/electrolux_status/__init__.py
@@ -89,12 +89,12 @@ class ElectroluxStatusDataUpdateCoordinator(DataUpdateCoordinator):
             for appliance in appliances_json:
                 connection_state = await self.hass.async_add_executor_job(self.api.getApplianceConnectionState, appliance)
                 appliance_state = await self.hass.async_add_executor_job(self.api.getApplianceState, appliance)
-                applicance_alias = appliances_json[appliance].get('alias')
-                applicance_name = applicance_alias if applicance_alias is not None else appliance
-                app = Appliance(applicance_name, appliance, appliances_json[appliance]['brand'],
+                appliance_alias = appliances_json[appliance].get('alias')
+                appliance_name = appliance_alias if appliance_alias is not None else appliance
+                app = Appliance(appliance_name, appliance, appliances_json[appliance]['brand'],
                                 appliances_json[appliance]['model'])
-                app.setup(ElectroluxLibraryEntity(applicance_name, connection_state, appliance_state))
-                found_appliances[applicance_name] = app
+                app.setup(ElectroluxLibraryEntity(appliance_name, connection_state, appliance_state))
+                found_appliances[appliance_name] = app
             return {
                 "appliances": Appliances(found_appliances)
             }

--- a/custom_components/electrolux_status/__init__.py
+++ b/custom_components/electrolux_status/__init__.py
@@ -89,10 +89,9 @@ class ElectroluxStatusDataUpdateCoordinator(DataUpdateCoordinator):
             for appliance in appliances_json:
                 connection_state = await self.hass.async_add_executor_job(self.api.getApplianceConnectionState, appliance)
                 appliance_state = await self.hass.async_add_executor_job(self.api.getApplianceState, appliance)
-                appliance_alias = appliances_json[appliance].get('alias')
-                appliance_name = appliance_alias if appliance_alias is not None else appliance
-                app = Appliance(appliance_name, appliance, appliances_json[appliance]['brand'],
-                                appliances_json[appliance]['model'])
+                appliance_name = appliances_json[appliance]['alias'] or appliance
+                appliance_model = appliances_json[appliance]['model'] or appliances_json[appliance]['pnc']
+                app = Appliance(appliance_name, appliance, appliances_json[appliance]['brand'], appliance_model)
                 app.setup(ElectroluxLibraryEntity(appliance_name, connection_state, appliance_state))
                 found_appliances[appliance_name] = app
             return {


### PR DESCRIPTION
I have a Washer + Dryer setup in my electrolux account, but wasn't seeing this reflected in home assistant.

When I dug into it, it turns out that not all appliances return a "model" number, however the "pnc" is a proxy for this, and I may open a PR for the python library to add a mapping of known models from the pnc for those that don't return it in the api.

In the meantime, this defaults the model to the 'pnc' value if model is not set.
With this change I see both appliances in Home Assistant.