### PR TITLE
Update pyelecrtoluxconnect to 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Tested with Electrolux and AEG washer-dryer, but probably could be used with som
 - ELECTROLUX EWF1041ZDWA - UltimateCare 900 AutoDose
 - AEG L6FBG841CA - 6000 Series Autodose
 - AEG L7FENQ96 - 7000 Series ProSteam Autodose
+- AEG L7FBE941Q - 7000 Series Prosense Autodose
 - AEG L8FEC96QS - 8000 Series Ökomix Autodose
 - AEG L9WBA61BC - 9000 Series ÖKOKombi DualSense SensiDry
 

--- a/custom_components/electrolux_status/manifest.json
+++ b/custom_components/electrolux_status/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/mauro-midolo/homeassistant_electrolux_status",
   "issue_tracker": "https://github.com/mauro-midolo/homeassistant_electrolux_status/issues",
   "requirements": [
-    "pyelectroluxconnect==0.3.2"
+    "pyelectroluxconnect==0.3.3"
   ],
   "ssdp": [],
   "zeroconf": [],


### PR DESCRIPTION
Update `pyelecrtoluxconnect` for including issue fix described in https://github.com/tomeko12/pyelectroluxconnect/issues/5

I couldn't connect to my AEG L7FBE941Q - 7000 Series Prosense Autodose, but after this update, it works! :relaxed: 

Btw, thanks for the integration :heart_eyes: 