### PR TITLE
Add Remote Control status

### DIFF
--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -227,6 +227,13 @@ class Appliance:
             )
             entities.append(
                 ApplianceSensor(
+                    name=f"{data.get_name()} Remote Control{data.get_suffix('RemoteControl',src)}",
+                    attr='RemoteControl',
+                    source=src,
+                )
+            )
+            entities.append(
+                ApplianceSensor(
                     name=f"{data.get_name()} Temperature{data.get_suffix('DisplayTemperature',src)}",
                     attr='DisplayTemperature', field='container',
                     device_class=SensorDeviceClass.TEMPERATURE,


### PR DESCRIPTION
Adding the status of remote control, this can help users determine if commands can successfully be sent to appliance.
Should close #46 