### PR TITLE
Added more entity for Electrolux EW9F149SP PerfectCare and Electrolux EW9H188SPC PerfectCare

### DIFF
--- a/custom_components/electrolux_status/const.py
+++ b/custom_components/electrolux_status/const.py
@@ -76,9 +76,11 @@ sensors_binary = {
 # Sensor Name: [value field, device class, invert]
     "DoorState": ["numberValue", BinarySensorDeviceClass.DOOR, None],
     "DoorLock":  ["numberValue", BinarySensorDeviceClass.LOCK, True],
+    # Washing Machine - Electrolux EW9F149SP PerfectCare
+    # Dryer - Electrolux EW9H188SPC PerfectCare
     "UiLockMode": ["numberValue", None, None],
     "EndOfCycleSound": ["numberValue", None, None],
-    # Washing Machine
+    # Washing Machine - Electrolux EW9F149SP PerfectCare
     "DefaultSoftPlus": ["numberValue", None, None],
     "PreWashPhase": ["numberValue", None, None],
     "RinseHold": ["numberValue", None, None],
@@ -87,7 +89,7 @@ sensors_binary = {
     "WMEconomy": ["numberValue", None, None],
     "AnticreaseWSteam": ["numberValue", None, None],
     "AnticreaseNoSteam": ["numberValue", None, None],
-    # Dryer
+    # Dryer - Electrolux EW9H188SPC PerfectCare
     "Refresh": ["numberValue", None, None],
     "ReversePlus": ["numberValue", None, None],
     "Delicate": ["numberValue", None, None],

--- a/custom_components/electrolux_status/const.py
+++ b/custom_components/electrolux_status/const.py
@@ -48,12 +48,52 @@ sensors = {
     "SensorTemperature": ["container", SensorDeviceClass.TEMPERATURE, TEMP_CELSIUS],
     "TargetTemperature": ["container", SensorDeviceClass.TEMPERATURE, TEMP_CELSIUS],
     "DefrostTemperature": ["container", SensorDeviceClass.TEMPERATURE, TEMP_CELSIUS],
+    # Washing Machine - Electrolux EW9F149SP PerfectCare
+    # Dryer - Electrolux EW9H188SPC PerfectCare
+    "StartTime": [None, None, TIME_MINUTES],
+    "ApplianceTotalWorkingTime": [None, None, TIME_MINUTES],
+    "TotalCycleCounter": [None, None, None],
+    "WaterHardness": ["valueTransl", None, None],
+    # Washing Machine - Electrolux EW9F149SP PerfectCare
+    "DefaultExtraRinse": ["numberValue", None, None],
+    "WaterSoftenerMode": [None, None, None],
+    "ApplianceMode": [None, None, None],
+    "FCTotalWashCyclesCount": [None, None, None],
+    "FCTotalWashingTime": [None, None, None],
+    "SteamValue": ["valTransl", None, None],
+    "ELUXTimeManagerLevel": ["valTransl", None, None],
+    "AnalogSpinSpeed": ["valTransl", None, None],
+    # Dryer - Electrolux EW9H188SPC PerfectCare
+    "WaterTankWarningMode": [None, None, None],
+    "DryingTime": [None, None, None],
+    "HumidityTarget": ["valTransl", None, None],
+    "AntiCreaseValue": [None, None, None],
+    "DrynessValue": ["valTransl", None, None],
+    "ProgramUID": ["valTransl", None, None]
 }
 
 sensors_binary = {
 # Sensor Name: [value field, device class, invert]
     "DoorState": ["numberValue", BinarySensorDeviceClass.DOOR, None],
     "DoorLock":  ["numberValue", BinarySensorDeviceClass.LOCK, True],
+    "UiLockMode": ["numberValue", None, None],
+    "EndOfCycleSound": ["numberValue", None, None],
+    # Washing Machine
+    "DefaultSoftPlus": ["numberValue", None, None],
+    "PreWashPhase": ["numberValue", None, None],
+    "RinseHold": ["numberValue", None, None],
+    "NightCycle": ["numberValue", None, None],
+    "Stain": ["numberValue", None, None],
+    "WMEconomy": ["numberValue", None, None],
+    "AnticreaseWSteam": ["numberValue", None, None],
+    "AnticreaseNoSteam": ["numberValue", None, None],
+    # Dryer
+    "Refresh": ["numberValue", None, None],
+    "ReversePlus": ["numberValue", None, None],
+    "Delicate": ["numberValue", None, None],
+    "TDEnergyLabel": ["numberValue", None, None],
+    "TDEconomy_Eco": ["numberValue", None, None],
+    "TDEconomy_Night": ["numberValue", None, None],
 }
 
 sensors_diagnostic = {

--- a/custom_components/electrolux_status/translations/pl.json
+++ b/custom_components/electrolux_status/translations/pl.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Electrolux Status",
+        "description": "Jeśli potrzebujesz pomocy przy konfiguracji, zerknij tutaj: https://github.com/mauro-midolo/homeassistant_electrolux_status",
+        "data": {
+          "username": "Nazwa użytkownika",
+          "password": "Hasło",
+          "region": "Region (emea, apac, na, latam or frigidaire)",
+          "language": "Electrolux udostępnia nazwy czujników i wartości języka"
+        }
+      }
+    },
+    "error": {
+      "auth": "Nazwa użytkownika lub hasło jest nieprawidłowe."
+    },
+    "abort": {
+      "single_instance_allowed": "Dozwolona jest tylko jedna instancja."
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "data": {
+          "scan_interval": "Interwał aktualizacji API (sekundy)"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added support for take values from nested `container` key. Added much more entity for:

Electrolux EW9F149SP PerfectCare (Washing Machine): 
- StartTime
- ApplianceTotalWorkingTime
- TotalCycleCounter
- WaterHardness
- DefaultExtraRinse
- WaterSoftenerMode
- ApplianceMode
- FCTotalWashCyclesCount
- FCTotalWashingTime
- SteamValue
- ELUXTimeManagerLevel
- AnalogSpinSpeed
- UiLockMode
- EndOfCycleSound
- DefaultSoftPlus
- PreWashPhase
- RinseHold
- NightCycle
- Stain
- WMEconomy
- AnticreaseWSteam
- AnticreaseNoSteam

Electrolux EW9H188SPC PerfectCare (Dryer):
- StartTime
- ApplianceTotalWorkingTime
- TotalCycleCounter
- WaterHardness
- WaterTankWarningMode
- DryingTime
- HumidityTarget
- AntiCreaseValue
- DrynessValue
- ProgramUID
- UiLockMode
- EndOfCycleSound
- Refresh
- ReversePlus
- Delicate
- TDEnergyLabel
- TDEconomy_Eco
- TDEconomy_Night