### PR TITLE
Multiple sets of attribute exist in API response

### DIFF
--- a/custom_components/electrolux_status/api.py
+++ b/custom_components/electrolux_status/api.py
@@ -72,10 +72,13 @@ class ElectroluxLibraryEntity:
         for k in self.states:
             if attr_name == self.states[k].get("name") and source == self.states[k].get("source"):
                 return self._get_states(self.states[k], field) if field else self._get_states(self.states[k])
+            attr_val = None
             for c in self.states[k].get("container", []):
                 if attr_name == self.states[k]["container"][c].get("name"):
-                    return self._get_states(self.states[k]["container"][c], field) if field else self._get_states(
+                    attr_val = self._get_states(self.states[k]["container"][c], field) if field else self._get_states(
                         self.states[k]["container"][c])
+            if attr_val is not None:
+                return attr_val
         return None
 
     @staticmethod


### PR DESCRIPTION
I have an Electrolux Washer and a Dryer, it was bugging me that some attributes were "unknown" or incorrect.

Looking at the `get_from_states()` function in `api.py` it will return the value of the first instance of attr_name found. This can result in the incorrect value being returned due to parameter ordering.

For example; "UserSelections", looks and sounds like it is a container of overrides for "ProgramParameters", but because it is further down in the JSON API response the values do not get returned.

```
state={'data_format': 'uint8', 'name': 'HumidityTarget', 'type': 'Serializable', 'visibility': 'visible', 'access': 'readwrite', 'nameTransl': 'Dryness Level', 'propertyName': 'HumidityTarget', 'tId': 'c', 'group': 0, 'numberValue': 0}, field=valTransl
state={'data_format': 'uint8', 'name': 'HumidityTarget', 'type': 'Serializable', 'visibility': 'visible', 'access': 'readwrite', 'nameTransl': 'Dryness Level', 'propertyName': 'HumidityTarget', 'tId': 'c', 'group': 0, 'numberValue': 32, 'valTransl': 'Cupboard Dry'}, field=valTransl
```

"UserSelections" is a subset of "ProgramParameters" for my appliances, makes sense. The attribute either; doesn't exist, is the same, or is an override like the example above.

I updated `get_from_states()` function so that instead of returning instantly, it will parse to the end and overwrite `attr_val` as it goes, then returning the value.