### PR TITLE
Sensors cannot be EntityCategory.CONFIG

### DIFF
--- a/custom_components/electrolux_status/const.py
+++ b/custom_components/electrolux_status/const.py
@@ -51,9 +51,6 @@ sensors = {
         "DefrostTemperature": ["container", SensorDeviceClass.TEMPERATURE, TEMP_CELSIUS],
         "TargetMicrowavePower": ["numberValue", SensorDeviceClass.ENERGY, POWER_WATT],
         "OvenProcessIdentifier": ["valueTransl", None, None],
-    },
-# Device config sensors
-    EntityCategory.CONFIG : {
         "RemoteControl": [None, None, None],
         "DefaultExtraRinse": ["numberValue", None, None],
         "TargetTemperature": ["container", SensorDeviceClass.TEMPERATURE, TEMP_CELSIUS],
@@ -92,9 +89,6 @@ sensors_binary = {
         "DoorState": ["numberValue", BinarySensorDeviceClass.DOOR, None],
         "DoorLock":  ["numberValue", BinarySensorDeviceClass.LOCK, True],
         "UiLockMode": ["numberValue", None, None],
-    },
-# Device config sensors
-    EntityCategory.CONFIG : {
         "EndOfCycleSound": ["numberValue", None, None],
         "DefaultSoftPlus": ["numberValue", None, None],
         "PreWashPhase": ["numberValue", None, None],


### PR DESCRIPTION
Should fix #143 caused by https://github.com/home-assistant/core/pull/101471

I am not running 2023.11.x yet, so haven't tested.